### PR TITLE
Use git_ref instead of master

### DIFF
--- a/trigger/git-template.yaml
+++ b/trigger/git-template.yaml
@@ -65,7 +65,7 @@ spec:
               type: git
               params:
                 - name: revision
-                  value: master
+                  value: $(params.git_ref)
                 - name: url
                   value: $(params.repo_url)
           - name: s2i-custom-notebook


### PR DESCRIPTION
Current setup bases all builds on `master` branch for any build of any imaginable tag or GitHub release. Resulting image is then tagged with same git tag as the build was requested with. This can cause confusion, since the image content may not match the git tag, while the image tag matches.

#### Example:

1. Tag a git revision on any other commit than `master` HEAD. For example a backported fix of an older release branch - lets's say current release is `2.0`, I'm creating a tag `1.8.2`.
2. Push the tag
3. Build is triggered
4. Image with the same tag  `1.8.2` as the git tag is produced

#### Results:
Image is expected to contain the repository at the git tag revision. In reality it contains the current master

#### Expected result:
Image tag fully corresponds to git tag = image content matches the git repository at the git tag revision.